### PR TITLE
Fix build by removing unknown property

### DIFF
--- a/precise/src/controls/catalog_viewer/CatalogViewerColumn.tsx
+++ b/precise/src/controls/catalog_viewer/CatalogViewerColumn.tsx
@@ -78,8 +78,7 @@ const CatalogViewerColumn: React.FC<CatalogViewerColumnProps> = ({
         return (
             <div key={index} className="viewer_samplevalue" title={value}>
                 {displayValue}
-                <CopyLink 
-                    value={value} 
+                <CopyLink
                     copy={() => navigator.clipboard.writeText(value)} 
                 />
             </div>


### PR DESCRIPTION
## Description

Fixing an issue when `npm run build` fails:
```
src/controls/catalog_viewer/CatalogViewerColumn.tsx:82:21 - error TS2322: Type '{ value: string; copy: () => Promise<void>; }' is not assignable to type 'IntrinsicAttributes & CopyLinkProps'.
  Property 'value' does not exist on type 'IntrinsicAttributes & CopyLinkProps'.
82                     value={value}
                       ~~~~~
```

This is because the `value` is an unknown and not required property of the <CopyLink> component.

## Additional context and related issues

Issue: https://github.com/trinodb/trino-query-ui/issues/8

This project currently lacks GHA workflows for automated testing, building, and publishing to find similar issues automatically. This will be addressed separately.