### PR TITLE
fix: remove hostname from nextUri using regex

### DIFF
--- a/precise/src/AsyncTrinoClient.tsx
+++ b/precise/src/AsyncTrinoClient.tsx
@@ -66,7 +66,8 @@ class TrinoQueryRunner {
             state.stats.state = 'CANCELLING'
             this.state = state
             this.setStatus(state)
-            const nextUri = state.nextUri.replace('http://localhost:8080', '')
+            const nextUri = state.nextUri.replace(/^https?:\/\/[^/]+/, '')
+
             // cancel query
             fetch(nextUri, {
                 method: 'DELETE',
@@ -255,7 +256,7 @@ class TrinoQueryRunner {
     async NextPage(previous: any) {
         try {
             // fix cors for testing
-            const nextUri = await previous.nextUri.replace('http://localhost:8080', '')
+            const nextUri = await previous.nextUri.replace(/^https?:\/\/[^/]+/, '')
             const response = await fetch(nextUri, {
                 method: 'GET',
                 headers: {


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Use regex instead of hardcoded url to remove hostname from nextUri. This allows us to use a different proxy target in [vite.config.ts](https://github.com/trinodb/trino-query-ui/blob/main/precise/vite.config.ts)

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

