### PR TITLE
Set registry url in release GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci

--- a/precise/package.json
+++ b/precise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trino-query-ui",
   "description": "Trino Query Editor react component",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",


### PR DESCRIPTION
## Description

Fix the publish github action to use the configured npm secret and ensure authentication works correctly during the publish step.

This PR contains two commits: one for the main change and another to bump the version, in order to keep a clean commit history on the main bran

## Additional context and related issues

Publish GHA currently gives error: 
```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
npm error need auth You need to authorize this machine using `npm adduser`
```

This happens because `registry-url` is not set in the node setup step, so the required .npmrc file is never created and npm is not authenticated against the registry.
