### PR TITLE
Fix release workflow version detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
 
       - id: version
         uses: EndBug/version-check@v2
+        with:
+          file-name: ./precise/package.json
+          diff-search: true
 
       - if: steps.version.outputs.changed == 'true'
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Description

The `release-and-publish` github action is currently failing on the main branch when attempting to detect a version change, producing the following error:
```
Error: Can't find version field
```

To fix this, we need to update the configuration as follows:
* Add `file-name: ./precise/package.json` so the action looks for package.json in the correct directory. Setting a job-level working-directory is not sufficient for this action.
* Add `diff-search: true` : By default, the action only checks commit messages. If the version is bumped in `package.json` without explicitly mentioning it in the commit message, the release is not detected.

## Additional context and related issues

These changes were tested independently in a forked repository
