### PR TITLE
Release v0.1.2

### DIFF
--- a/precise/package-lock.json
+++ b/precise/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trino-query-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trino-query-ui",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/precise/package.json
+++ b/precise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trino-query-ui",
   "description": "Trino Query Editor react component",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",


### PR DESCRIPTION
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Cutting another release.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Jumping from 0.1.1 to 0.1.2 to stay below the full release at 1.0.0 in the near future. We changed quite a bit since that release but its all in early development so to speak. Specifically dependencies and moving to Material UI.

All automation is in place now so that a merge should trigger everything including publishing to npmjs.org. 
