### PR TITLE
Adjust to trusted publishing to npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  id-token: write  # Required for OIDC/Trusted Publishing
   contents: write
 
 jobs:
@@ -39,11 +40,9 @@ jobs:
         with:
           node-version: '24' # Use latest LTS version
           registry-url: https://registry.npmjs.org
-
+          scope: '@trinodb'
       - if: steps.version.outputs.changed == 'true'
         run: |
           npm ci
           npm run build
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --access public

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See details in the [demo animation](./demos.gif).
 ## Installation
 
 ```shell
-npm install trino-query-ui
+npm install @trinodb/trino-query-ui
 ```
 
 ## Quick start

--- a/precise/package.json
+++ b/precise/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "trino-query-ui",
+  "name": "@trinodb/trino-query-ui",
   "description": "Trino Query Editor react component",
   "version": "0.1.2",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",
     "url": "https://github.com/trinodb/trino-query-ui/graphs/contributors"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "trino",


### PR DESCRIPTION
## Description

Update to trusted publishing flow. Pending set up on npm registry by @martint

See https://github.com/simpligility/trino-js-client/pull/new/trusted-publish and https://docs.npmjs.com/trusted-publishers 

## Additional context and related issues

See also https://github.com/trinodb/trino-js-client/pull/953