### PR TITLE
Add CSV Download Functionality to ResultSet Component

### DIFF
--- a/precise/src/ResultSet.tsx
+++ b/precise/src/ResultSet.tsx
@@ -21,6 +21,7 @@ import Chip, { ChipProps } from '@mui/material/Chip'
 import ReactDOMServer from 'react-dom/server'
 import CopyLink from './utils/CopyLink'
 import ClearButton from './utils/ClearButton'
+import DownloadCsvButton from './utils/DownloadCsvButton'
 
 interface ResultSetProps {
     queryId: string | undefined
@@ -254,6 +255,39 @@ class ResultSet extends React.Component<ResultSetProps> {
         return tableText
     }
 
+    formatTableAsCsv(results: any[], columns: any[]): string {
+        if (!columns || columns.length === 0) {
+            return ''
+        }
+
+        const escapeCell = (value: any): string => {
+            if (value == null) return ''
+            const str = String(value)
+            if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+                return `"${str.replace(/"/g, '""')}"`
+            }
+            return str
+        }
+
+        const header = columns.map((column: any) => escapeCell(column.name)).join(',')
+        const rows = results
+            .flat()
+            .map((row: any[]) => row.map((cell: any) => escapeCell(cell)).join(','))
+        return [header, ...rows].join('\n')
+    }
+
+    downloadCsv() {
+        const { results, columns, queryId } = this.props
+        const csvContent = this.formatTableAsCsv(results, columns)
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `${queryId ?? 'query'}.csv`
+        link.click()
+        URL.revokeObjectURL(url)
+    }
+
     copy() {
         const { results, columns } = this.props
         const htmlContent = ReactDOMServer.renderToString(this.renderInnerTable(results, this.props.response, columns))
@@ -355,6 +389,7 @@ class ResultSet extends React.Component<ResultSetProps> {
                                     <>
                                         <ClearButton onClear={() => this.props.onClearResults(queryId)} />
                                         <CopyLink copy={() => this.copy()} />
+                                        <DownloadCsvButton download={() => this.downloadCsv()} />
                                     </>
                                 ) : null
                             ) : null}

--- a/precise/src/utils/DownloadCsvButton.tsx
+++ b/precise/src/utils/DownloadCsvButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Button, Tooltip } from '@mui/material'
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined'
+
+interface DownloadCsvButtonProps {
+    download: () => void
+}
+
+const DownloadCsvButton: React.FC<DownloadCsvButtonProps> = ({ download }) => {
+    return (
+        <Tooltip title="Download as CSV">
+            <Button
+                variant="outlined"
+                color="primary"
+                size="small"
+                sx={{ fontSize: '0.5rem' }}
+                startIcon={<DownloadOutlinedIcon sx={{ fontSize: '0.5rem' }} />}
+                onClick={download}
+            >
+                CSV
+            </Button>
+        </Tooltip>
+    )
+}
+
+export default DownloadCsvButton


### PR DESCRIPTION
## Summary

This PR adds the ability to download query results directly as a CSV file from the query results pane.

A new **CSV** action button has been added to the results toolbar alongside the existing actions. When clicked, the current result set is dynamically converted into a CSV file and downloaded locally. The generated file is automatically named using the corresponding `queryId`.

## Implementation Details

The exported CSV is generated in the browser and follows standard CSV formatting rules, including proper escaping of:

* Double quotes
* Commas
* Newline characters

Null and undefined values are exported as empty fields.

## UI Changes

A new **CSV** action button is added next to the existing actions in the results toolbar:

<img width="1788" height="773" alt="Screenshot 2026-06-19 at 10 26 25" src="https://github.com/user-attachments/assets/b24cc8ac-cfe9-4bec-9e33-84741672cc1f" />


## Example Behavior

Clicking the **CSV** button:

1. Formats the current query results as a CSV document.
2. Applies proper escaping for special characters.
3. Initiates a local file download.
4. Names the file using the associated `queryId`.

