### PR TITLE
Release v0.1.3

### DIFF
--- a/precise/package.json
+++ b/precise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trinodb/trino-query-ui",
   "description": "Trino Query Editor react component",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",


### PR DESCRIPTION
## Description

Bump the version from 0.1.2 to 0.1.3 to test npm trusted publishing in the CI release flow.

## Additional context and related issues

Trusted publishing was set up in https://github.com/trinodb/trino-query-ui/pull/35. However `npm publish` did not run after that PR was merged because the release workflow detected no version change in the latest commit ([see here](https://github.com/trinodb/trino-query-ui/blob/3313924401069c02f3e80798be5870883bb02c82/.github/workflows/release.yml#L44)).

This is expected behavior. This PR bumps the package version so the release workflow runs npm publish, allowing us to verify that trusted publishing works as expected.

