### PR TITLE
Release v0.1.4

### DIFF
--- a/precise/package-lock.json
+++ b/precise/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "trino-query-ui",
-  "version": "0.1.2",
+  "name": "@trinodb/trino-query-ui",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trino-query-ui",
-      "version": "0.1.2",
+      "name": "@trinodb/trino-query-ui",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -432,7 +431,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -476,7 +474,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1321,7 +1318,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.6.tgz",
       "integrity": "sha512-R4DaYF3dgCQCUAkr4wW1w26GHXcf5rCmBRHVBuuvJvaGLmZdD8EjatP80Nz5JCw0KxORAzwftnHzXVnjR8HnFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -1432,7 +1428,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.6.tgz",
       "integrity": "sha512-8fehAazkHNP1imMrdD2m2hbA9sl7Ur6jfuNweh5o4l9YPty4iaZzRXqYvBCWQNwFaSHmMEj2KPbyXGp7Bt73Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.6",
@@ -2037,7 +2032,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2066,7 +2060,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -2110,7 +2105,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2336,7 +2330,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2481,7 +2474,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2682,6 +2674,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2772,7 +2765,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3442,6 +3434,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3679,7 +3672,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3933,7 +3925,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -4102,7 +4095,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4187,7 +4179,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/precise/package.json
+++ b/precise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trinodb/trino-query-ui",
   "description": "Trino Query Editor react component",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",


### PR DESCRIPTION
## Description

Bump the version from 0.1.3 to 0.1.4 to exercise npm trusted publishing in the CI release flow for the first time.

## Additional context and related issues

The 0.1.3 release from #41 created the GitHub release, but `npm publish` failed with `404 Not Found - PUT https://registry.npmjs.org/@trinodb%2ftrino-query-ui` ([workflow run](https://github.com/trinodb/trino-query-ui/actions/runs/32174568019)).

The 404 is misleading. Trusted publishing cannot create a package that does not exist on the registry yet: the trusted publisher is configured in the package settings on npmjs.com, and that page only exists once the package does (see [npm/cli#8544](https://github.com/npm/cli/issues/8544)). With no trusted publisher to match the workflow against, the registry treats the run as anonymous, and an anonymous `PUT` returns 404 rather than 403 (see [npm/cli#8976](https://github.com/npm/cli/issues/8976)). The rename to the scoped `@trinodb/trino-query-ui` name in #35 meant the package was brand new, so it hit exactly this case.

To unblock it, `@trinodb/trino-query-ui@0.1.3` was published manually with an authenticated npm account, which is the documented bootstrap path. That version is now on the registry, so a trusted publisher can be configured for it — GitHub Actions, `trinodb/trino-query-ui`, workflow `release.yml`.

This bump verifies the OIDC path end to end. Merging it should publish 0.1.4 from CI with no token involved, and npm generates a provenance attestation automatically for trusted publishing from a public repository.

Note that 0.1.3 was published manually and therefore carries no provenance attestation. 0.1.4 will be the first release with one.

## Lockfile resync

This branch also resyncs `precise/package-lock.json`, which had drifted from `package.json`. The lockfile was still recording version `0.1.2` and the pre-rename package name `trino-query-ui`.

The cause is the release process, not the release workflow. Release pull requests edit `precise/package.json` by hand — #41 changed that one file only — while `.github/workflows/release.yml` runs `npm ci`, which installs strictly from the lockfile and never writes to it. Nothing in the pipeline ever propagates a version bump into the lockfile, so each release commit that edits `package.json` alone widens the gap. The same happened to the `Release v0.1.1` commit that came in via #23, and was silently repaired later by an unrelated `npm install` in #26.

`npm ci` does not fail on this, since it validates the lockfile against the declared dependencies and not against the root `name` and `version`, which is why it went unnoticed.

The lockfile here was regenerated with `npm install --package-lock-only`. It is a metadata-only change: 309 packages before and after, none added or removed, no `resolved` or `integrity` differences, and no dependency version changes — only the root `name` and `version` plus normalization of some stale `peer` and `optional` markers. `npm ci` was verified against it.

To avoid reintroducing the drift, future releases should bump the version with `npm version <version> --no-git-tag-version` from `precise/`, which writes both files, rather than editing `package.json` directly.
