### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24' # Use latest LTS version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,25 +18,25 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - id: version
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@v3
         with:
           file-name: ./precise/package.json
           diff-search: true
 
       - if: steps.version.outputs.changed == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
 
       - if: steps.version.outputs.changed == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24' # Use latest LTS version
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Description

Update all four GitHub Actions used in the CI and release workflows to their latest majors, which run on the Node 24 action runtime.

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v6 | v7 |
| `actions/setup-node` | v6 | v7 |
| `EndBug/version-check` | v2 | v3 |
| `softprops/action-gh-release` | v2 | v3 |

## Additional context and related issues

The [release run for 0.1.3](https://github.com/trinodb/trino-query-ui/actions/runs/32174568019) raised this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: EndBug/version-check@v2, softprops/action-gh-release@v2.

See the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for the deprecation. Both actions have since published a major release on Node 24, so this pins them there rather than relying on the runner's forced fallback.

Notes on the individual bumps:

- [`EndBug/version-check@v3`](https://github.com/EndBug/version-check/releases/tag/v3.0.0) is a drop-in replacement. The `file-name` and `diff-search` inputs and the `changed` and `version` outputs used by the release workflow are unchanged; the major bump is the Node 24 runtime and dependency updates.
- [`softprops/action-gh-release@v3`](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) is explicitly documented as a runtime-only major: "a major release that moves the action runtime from Node 20 to Node 24."
- [`actions/setup-node@v7`](https://github.com/actions/setup-node/releases/tag/v7.0.0) additionally [removes its dummy `NODE_AUTH_TOKEN` export](https://github.com/actions/setup-node/pull/1558). That placeholder value was visible in the failed publish step's environment as `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`, so dropping it is welcome now that publishing authenticates through OIDC rather than a token.
- [`actions/checkout@v7`](https://github.com/actions/checkout/releases/tag/v7.0.0) moves to ESM and blocks checking out fork PR code for `pull_request_target` and `workflow_run` triggers. Neither workflow uses those triggers, so the change does not affect this repository.
