### PR TITLE
Point dependabot at the npm manifest in precise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,6 @@ updates:
       interval: "weekly"
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/precise"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Description

Point the dependabot npm ecosystem entry at `/precise`, where the only `package.json` in this repository lives. It was set to `/`, where there is no manifest.

## Additional context and related issues

Dependabot resolves `directory` against the repository root and looks for a manifest there. With `directory: "/"` and no `package.json` at the root, the npm entry has never had anything to scan.

The effect is visible in the pull request history: since `.github/dependabot.yml` was added in #24, every dependabot pull request has come from the `github-actions` ecosystem — #33 and #34 — and not a single one from npm. The npm dependencies have therefore gone unmonitored the whole time.

The `github-actions` entry stays at `/` and is correct as-is: dependabot always discovers workflow files under `.github/workflows` from the repository root, regardless of where the rest of the project sits.

Expect a batch of npm pull requests shortly after this merges, since dependabot will be looking at `precise/package.json` for the first time.
