### PR TITLE
Group web UI dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,15 @@ updates:
     directory: "/precise"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: "all"
+    ignore:
+      # Ignore major updates for all dependencies; allow only minor/patch updates.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Description

Group dependabot updates dependencies to reduce PR volume.

## Additional context and related issues

Similar things to the web ui in the main trino repo introduced by:
* https://github.com/trinodb/trino/pull/30690
* https://github.com/trinodb/trino/pull/30710

