### PR TITLE
Release v0.1.5

### DIFF
--- a/precise/package-lock.json
+++ b/precise/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trinodb/trino-query-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trinodb/trino-query-ui",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/precise/package.json
+++ b/precise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trinodb/trino-query-ui",
   "description": "Trino Query Editor react component",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Trino contributors",
     "email": "general@trino.io",


### PR DESCRIPTION
## Description

Bump the version from 0.1.4 to 0.1.5.

## Additional context and related issues

This release is a second end-to-end verification of the automated release flow, after 0.1.4 confirmed that npm trusted publishing works. 0.1.4 only published on a re-run, after the trusted publisher configuration on npmjs.com was corrected, so this release checks that a merge publishes on the first attempt with no manual intervention.

It is also the first release prepared with the process documented in #51. The version was bumped with `npm version 0.1.5 --no-git-tag-version` from `precise`, so `package.json` and `package-lock.json` move together and the drift fixed in #42 does not return.

Merging this should create the 0.1.5 GitHub release and publish the package to npm over OIDC, with a provenance attestation and no token involved.
