### PR TITLE
Publish to npm before creating the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,20 +29,28 @@ jobs:
           diff-search: true
 
       - if: steps.version.outputs.changed == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: ${{ steps.version.outputs.version }}
-          generate_release_notes: true
-
-      - if: steps.version.outputs.changed == 'true'
         uses: actions/setup-node@v7
         with:
           node-version: '24' # Use latest LTS version
           registry-url: https://registry.npmjs.org
           scope: '@trinodb'
+
       - if: steps.version.outputs.changed == 'true'
-        run: |
-          npm ci
-          npm run build
-          npm publish --access public
+        name: Install dependencies
+        run: npm ci
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Build package
+        run: npm run build
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Publish to npm
+        run: npm publish --access public
+
+      - if: steps.version.outputs.changed == 'true'
+        name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -200,9 +200,13 @@ npm run check
 
 Releases are automated. The [release
 workflow](.github/workflows/release.yml) runs on every push to `main`. When it
-detects a changed version in **precise/package.json**, it creates a GitHub
-release with generated release notes and publishes the package to npm. Pushes
+detects a changed version in **precise/package.json**, it publishes the package
+to npm and then creates a GitHub release with generated release notes. Pushes
 that leave the version untouched publish nothing.
+
+Publishing runs before the release is created, so a failed publish leaves
+neither a release nor a tag behind, and the workflow run can be repeated once
+the cause is fixed.
 
 Bump the version from the `precise` directory:
 


### PR DESCRIPTION
## Description

Publish to npm before creating the GitHub release, and split the combined install, build, and publish step into named steps.

## Additional context and related issues

The workflow currently creates the GitHub release first and publishes afterwards. A failing publish therefore leaves a release and a tag behind for a version that never reached npm, and that release has to be deleted by hand before the run can be repeated.

This is what happened during the release of 0.1.3 in #41. The [run](https://github.com/trinodb/trino-query-ui/actions/runs/32174568019) created the release, then failed to publish, because trusted publishing cannot create a package that does not exist on the registry yet. The release for 0.1.4 in #42 was created the same way while its publish failed, and only a later rerun of that job actually published the version.

With the publish first, a failed publish leaves nothing behind, and rerunning the failed job is enough once the cause is fixed. The same ordering is used in the release workflow of trino-js-client, in [trino-js-client#953](https://github.com/trinodb/trino-js-client/pull/953).

### Named steps

The install, build, and publish commands all ran inside a single `run` block, so the logs labelled all three "Run npm ci". Every publish failure this repository has seen was therefore reported under a step name that pointed at the install. Splitting them makes the failing command obvious from the job summary alone.

The README description of the release flow is updated to match the new order.
